### PR TITLE
fix: use bitwise not instead of logical not

### DIFF
--- a/src/main/scala/router/SwitchAllocator.scala
+++ b/src/main/scala/router/SwitchAllocator.scala
@@ -27,7 +27,7 @@ class SwitchArbiter(inN: Int, outN: Int, outParams: Seq[ChannelParams], egressPa
   val mask = RegInit(0.U(inN.W))
   val choices = Wire(Vec(outN, UInt(inN.W)))
 
-  var sel = PriorityEncoderOH(Cat(unassigned, unassigned & !mask))
+  var sel = PriorityEncoderOH(Cat(unassigned, unassigned & ~mask))
   for (i <- 0 until outN) {
     choices(i) := sel | (sel >> inN)
     sel = PriorityEncoderOH(unassigned & ~choices(i))


### PR DESCRIPTION
Hi all,
First of all, thank you for developing and maintaining this interesting project.

Some days ago, I found a suspicious part that seems to be a bug. The code actually does work, but not in an intended way I think.
The `mask` reg in `SwitchArbiter` seems to be used to choose ports in serial order depending on the history. However, since logical not operator is used here instead of bitwise not, the type of inverted mask becomes `Bool` and masked flags will almost always be zero (or just one if mask === 0). So the `PriorityEncoder` effectively does not use the mask.
This introduces unintended priority into the input ports and might decrease performance of some network path.

Could you check it when you have time?
Thank you.