### PR TITLE
Remove empty parens from `fire` method calls

### DIFF
--- a/src/main/scala/channel/WidthWidget.scala
+++ b/src/main/scala/channel/WidthWidget.scala
@@ -23,7 +23,7 @@ object WidthWidget {
     out.bits.tail := in.bits.tail && last
     out.bits.payload := Mux(first, in.bits.payload, stored)
     in.ready := last && out.ready
-    when (out.fire()) {
+    when (out.fire) {
       count := Mux(last, 0.U, count + 1.U)
       stored := Mux(first, in.bits.payload, stored) >> outBits
     }
@@ -45,7 +45,7 @@ object WidthWidget {
     out.bits.tail := last && in.bits.tail
     out.bits.payload := Cat(in.bits.payload, payload.asUInt)
     in.ready := !last || out.ready
-    when (in.fire()) {
+    when (in.fire) {
       count := Mux(last, 0.U, count + 1.U)
       payload(count) := in.bits.payload
       when (first) {

--- a/src/main/scala/protocol/AXI4.scala
+++ b/src/main/scala/protocol/AXI4.scala
@@ -103,12 +103,12 @@ class AXI4MasterToNoC(
     for (id <- master.id.start until master.id.end) {
       arFIFOMap(id) := idTracker(
         arTag,
-        arSel(id) && io.axi4.ar.fire(),
-        rSel(id) && io.axi4.r.fire() && io.axi4.r.bits.last)
+        arSel(id) && io.axi4.ar.fire,
+        rSel(id) && io.axi4.r.fire && io.axi4.r.bits.last)
       awFIFOMap(id) := idTracker(
         awTag,
-        awSel(id) && io.axi4.aw.fire(),
-        bSel(id) && io.axi4.b.fire())
+        awSel(id) && io.axi4.aw.fire,
+        bSel(id) && io.axi4.b.fire)
     }
   }
 
@@ -145,7 +145,7 @@ class AXI4MasterToNoC(
   io.flits.w.bits.egress_id := Mux1H(requestWIO.zipWithIndex.map { case (r, i) =>
     r -> (slaveToEgressOffset(i) + 1).U
   })
-  when (io.flits.w.fire()) { w_first := in.w.bits.last }
+  when (io.flits.w.fire) { w_first := in.w.bits.last }
 
   io.flits.ar.valid := in.ar.valid
   in.ar.ready := io.flits.ar.ready
@@ -203,14 +203,14 @@ class AXI4SlaveToNoC(
   io.axi4.aw <> aw_q.io.deq
 
   out.aw.ready       := !aw_val(out.aw.bits.id)
-  when (out.aw.fire()) {
+  when (out.aw.fire) {
     aw_val(out.aw.bits.id) := true.B
     aw_buf(out.aw.bits.id) := out.aw.bits
   }
 
   aw_q.io.enq.valid := out.w.valid && Mux1H(out_w_in_id, aw_val) && out_w_in_head
   aw_q.io.enq.bits  :=                Mux1H(out_w_in_id, aw_buf)
-  when (aw_q.io.enq.fire()) {
+  when (aw_q.io.enq.fire) {
     aw_val(OHToUInt(out_w_in_id)) := false.B
     w_fire := true.B
   }
@@ -223,7 +223,7 @@ class AXI4SlaveToNoC(
     w_fire || (out_w_in_head && aw_q.io.enq.ready && Mux1H(out_w_in_id, aw_val))
   )
 
-  when (out.w.fire() && out.w.bits.last) { w_fire := false.B }
+  when (out.w.fire && out.w.bits.last) { w_fire := false.B }
 
   val r_first = RegInit(true.B)
   io.flits.r.valid := out.r.valid
@@ -234,7 +234,7 @@ class AXI4SlaveToNoC(
   io.flits.r.bits.egress_id := Mux1H(requestROI.zipWithIndex.map { case (r, i) =>
     r -> (masterToEgressOffset(i) + 0).U
   })
-  when (io.flits.r.fire()) { r_first := out.r.bits.last }
+  when (io.flits.r.fire) { r_first := out.r.bits.last }
 
   io.flits.b.valid := out.b.valid
   out.b.ready := io.flits.b.ready

--- a/src/main/scala/protocol/TilelinkAdapters.scala
+++ b/src/main/scala/protocol/TilelinkAdapters.scala
@@ -29,8 +29,8 @@ abstract class TLChannelToNoC[T <: TLChannel](gen: => T, edge: TLEdge, idToEgres
   val has_body = Wire(Bool())
   val body_fields = getBodyFields(protocol.bits)
   val const_fields = getConstFields(protocol.bits)
-  val head = edge.first(protocol.bits, protocol.fire())
-  val tail = edge.last(protocol.bits, protocol.fire())
+  val head = edge.first(protocol.bits, protocol.fire)
+  val tail = edge.last(protocol.bits, protocol.fire)
   def requestOH: Seq[Bool]
 
   val body  = Cat( body_fields.filter(_.getWidth > 0).map(_.asUInt))
@@ -47,8 +47,8 @@ abstract class TLChannelToNoC[T <: TLChannel](gen: => T, edge: TLEdge, idToEgres
   })
   io.flit.bits.payload    := Mux(is_body, body, const)
 
-  when (io.flit.fire() && io.flit.bits.head) { is_body := true.B }
-  when (io.flit.fire() && io.flit.bits.tail) { is_body := false.B }
+  when (io.flit.fire && io.flit.bits.head) { is_body := true.B }
+  when (io.flit.fire && io.flit.bits.tail) { is_body := false.B }
 }
 
 abstract class TLChannelFromNoC[T <: TLChannel](gen: => T)(implicit val p: Parameters) extends Module with TLFieldHelper {
@@ -81,8 +81,8 @@ abstract class TLChannelFromNoC[T <: TLChannel](gen: => T)(implicit val p: Param
   assign(const, const_fields)
   assign(io.flit.bits.payload, body_fields)
 
-  when (io.flit.fire() && io.flit.bits.head) { is_const := false.B; const_reg := io.flit.bits.payload }
-  when (io.flit.fire() && io.flit.bits.tail) { is_const := true.B }
+  when (io.flit.fire && io.flit.bits.head) { is_const := false.B; const_reg := io.flit.bits.payload }
+  when (io.flit.fire && io.flit.bits.tail) { is_const := true.B }
 }
 
 trait HasAddressDecoder {

--- a/src/main/scala/router/IngressUnit.scala
+++ b/src/main/scala/router/IngressUnit.scala
@@ -59,9 +59,9 @@ class IngressUnit(
   io.in.ready := route_buffer.io.enq.ready && (
     io.router_req.ready || !io.in.bits.head || at_dest)
 
-  route_q.io.enq.valid := io.router_req.fire()
+  route_q.io.enq.valid := io.router_req.fire
   route_q.io.enq.bits := io.router_resp
-  when (io.in.fire() && io.in.bits.head && at_dest) {
+  when (io.in.fire && io.in.bits.head && at_dest) {
     route_q.io.enq.valid := true.B
     route_q.io.enq.bits.vc_sel.foreach(_.foreach(_ := false.B))
     for (o <- 0 until nEgress) {
@@ -94,10 +94,10 @@ class IngressUnit(
     (route_q.io.deq.valid || !head) &&
     (io.vcalloc_req.ready || !head) &&
     (vcalloc_q.io.enq.ready || !head))
-  route_q.io.deq.ready := (route_buffer.io.deq.fire() && tail)
+  route_q.io.deq.ready := (route_buffer.io.deq.fire && tail)
 
 
-  vcalloc_q.io.enq.valid := io.vcalloc_req.fire()
+  vcalloc_q.io.enq.valid := io.vcalloc_req.fire
   vcalloc_q.io.enq.bits := io.vcalloc_resp
   assert(!(vcalloc_q.io.enq.valid && !vcalloc_q.io.enq.ready))
 
@@ -108,7 +108,7 @@ class IngressUnit(
   val vcalloc_tail = vcalloc_buffer.io.deq.bits.tail
   io.salloc_req(0).valid := vcalloc_buffer.io.deq.valid && vcalloc_q.io.deq.valid && c && !io.block
   vcalloc_buffer.io.deq.ready := io.salloc_req(0).ready && vcalloc_q.io.deq.valid && c && !io.block
-  vcalloc_q.io.deq.ready := vcalloc_tail && vcalloc_buffer.io.deq.fire()
+  vcalloc_q.io.deq.ready := vcalloc_tail && vcalloc_buffer.io.deq.fire
 
   val out_bundle = if (combineSAST) {
     Wire(Valid(new SwitchBundle(outParams, egressParams)))
@@ -117,7 +117,7 @@ class IngressUnit(
   }
   io.out(0) := out_bundle
 
-  out_bundle.valid := vcalloc_buffer.io.deq.fire()
+  out_bundle.valid := vcalloc_buffer.io.deq.fire
   out_bundle.bits.flit := vcalloc_buffer.io.deq.bits
   out_bundle.bits.flit.virt_channel_id := 0.U
   val out_channel_oh = vcalloc_q.io.deq.bits.vc_sel.map(_.reduce(_||_)).toSeq

--- a/src/main/scala/router/Router.scala
+++ b/src/main/scala/router/Router.scala
@@ -136,7 +136,7 @@ class Router(
     val route_computer = Module(new RouteComputer(routerParams, inParams, outParams, ingressParams, egressParams))
 
 
-    val fires_count = WireInit(PopCount(vc_allocator.io.req.map(_.fire())))
+    val fires_count = WireInit(PopCount(vc_allocator.io.req.map(_.fire)))
     dontTouch(fires_count)
 
 
@@ -212,13 +212,13 @@ class Router(
     }
 
     destNodes.map(_.in(0)).foreach { case (in, edge) => in.flit.map { f =>
-      sample(f.fire(), s"${edge.cp.srcId} $nodeId")
+      sample(f.fire, s"${edge.cp.srcId} $nodeId")
     } }
     ingressNodes.map(_.in(0)).foreach { case (in, edge) =>
-      sample(in.flit.fire(), s"i${edge.cp.asInstanceOf[IngressChannelParams].ingressId} $nodeId")
+      sample(in.flit.fire, s"i${edge.cp.asInstanceOf[IngressChannelParams].ingressId} $nodeId")
     }
     egressNodes.map(_.out(0)).foreach { case (out, edge) =>
-      sample(out.flit.fire(), s"$nodeId e${edge.cp.asInstanceOf[EgressChannelParams].egressId}")
+      sample(out.flit.fire, s"$nodeId e${edge.cp.asInstanceOf[EgressChannelParams].egressId}")
     }
 
   }

--- a/src/main/scala/router/SwitchAllocator.scala
+++ b/src/main/scala/router/SwitchAllocator.scala
@@ -49,12 +49,12 @@ class SwitchArbiter(inN: Int, outN: Int, outParams: Seq[ChannelParams], egressPa
       }
     }
     chosens = chosens | chosen
-    when (io.out(i).fire()) {
+    when (io.out(i).fire) {
       lock(i) := chosen & ~in_tails
     }
   }
 
-  when (io.out(0).fire()) {
+  when (io.out(0).fire) {
     mask := (0 until inN).map { i => (io.chosen_oh(0) >> i) }.reduce(_|_)
   } .otherwise {
     mask := Mux(~mask === 0.U, 0.U, (mask << 1) | 1.U(1.W))
@@ -94,7 +94,7 @@ class SwitchAllocator(
     arbs.zipWithIndex.foreach { case (a,i) =>
       a.io.in(idx).valid := o.valid && o.bits.vc_sel(i).reduce(_||_)
       a.io.in(idx).bits := o.bits
-      fires(i) := a.io.in(idx).fire()
+      fires(i) := a.io.in(idx).fire
     }
     o.ready := fires.reduce(_||_)
     idx += 1

--- a/src/main/scala/router/vcalloc/MultiVCAllocator.scala
+++ b/src/main/scala/router/vcalloc/MultiVCAllocator.scala
@@ -17,7 +17,7 @@ abstract class MultiVCAllocator(vP: VCAllocatorParams)(implicit p: Parameters) e
   val in_allocs = allInParams.zipWithIndex.map { case (iP,i) =>
     val a = Wire(MixedVec(allOutParams.map { u => Vec(u.nVirtualChannels, Bool()) }))
     a := Mux(io.req(i).valid,
-      inputAllocPolicy(io.req(i).bits.flow, io.req(i).bits.vc_sel, i.U, io.req(i).bits.in_vc, io.req(i).fire()),
+      inputAllocPolicy(io.req(i).bits.flow, io.req(i).bits.vc_sel, i.U, io.req(i).bits.in_vc, io.req(i).fire),
       0.U.asTypeOf(a))
     a
   }

--- a/src/main/scala/test/TestHarness.scala
+++ b/src/main/scala/test/TestHarness.scala
@@ -94,7 +94,7 @@ class InputGen(idx: Int, cParams: IngressChannelParams)
   out_payload.flits_fired := 0.U
 
   io.n_flits := packet_remaining + 1.U
-  io.fire := can_fire && io.out.fire()
+  io.fire := can_fire && io.out.fire
 
   when (io.fire && !io.out.bits.tail) {
     flits_left := packet_remaining
@@ -111,7 +111,7 @@ class InputGen(idx: Int, cParams: IngressChannelParams)
     out_payload := payload
     out_payload.flits_fired := flits_fired
 
-    when (io.out.fire()) {
+    when (io.out.fire) {
       flits_fired := flits_fired + 1.U
       flits_left := flits_left - 1.U
     }
@@ -206,7 +206,7 @@ class NoCTester(inputParams: Seq[IngressChannelParams], outputParams: Seq[Egress
     val packet_rob_idx = Reg(UInt(log2Ceil(robSz).W))
 
     val flow_ctrs = RegInit(VecInit.fill(outputParams(i).possibleFlows.size) { 0.U(8.W) })
-    when (o.flit.fire()) {
+    when (o.flit.fire) {
       val flows = outputParams(i).possibleFlows.toSeq
       val fifo = flows.filter(_.fifo).map(_.ingressId.U === o.flit.bits.ingress_id).orR
       val flow_id = flows.zipWithIndex.map { case (f, fid) =>
@@ -236,13 +236,13 @@ class NoCTester(inputParams: Seq[IngressChannelParams], outputParams: Seq[Egress
       when (o.flit.bits.head) { packet_valid := true.B; packet_rob_idx := rob_idx }
       when (o.flit.bits.tail) { packet_valid := false.B }
     }
-    rob_frees = rob_frees | ((o.flit.fire() && o.flit.bits.tail) << rob_idx)
+    rob_frees = rob_frees | ((o.flit.fire && o.flit.bits.tail) << rob_idx)
   }
 
 
   rob_valids := (rob_valids | rob_allocs) & ~rob_frees
   idle := rob_allocs === 0.U && rob_frees === 0.U
-  flits := flits + io.from_noc.map(_.flit.fire().asUInt).reduce(_+&_)
+  flits := flits + io.from_noc.map(_.flit.fire.asUInt).reduce(_+&_)
   txs := txs + PopCount(tx_fire)
 
   for (i <- 0 until robSz) {


### PR DESCRIPTION
This becomes a compilation error in Chisel 5.