### PR TITLE
Update deprecated Chisel API

### DIFF
--- a/src/main/scala/channel/Nodes.scala
+++ b/src/main/scala/channel/Nodes.scala
@@ -1,7 +1,7 @@
 package constellation.channel
 
 import chisel3._
-import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.experimental.SourceInfo
 import org.chipsalliance.cde.config.{Parameters, Field}
 import freechips.rocketchip.diplomacy._
 


### PR DESCRIPTION
This has been deprecated since Chisel 3.6.0. It is being removed in Chisel 6, and will become a compile error at that point.