### PR TITLE
Use new Chisel annotations API

### DIFF
--- a/src/main/scala/protocol/Protocol.scala
+++ b/src/main/scala/protocol/Protocol.scala
@@ -74,11 +74,9 @@ class ProtocolNoC(params: ProtocolNoCParams)(implicit p: Parameters) extends Mod
   })
   // END: ProtocolNoC
 
-  if (params.inlineNoC) chisel3.experimental.annotate(
-    new chisel3.experimental.ChiselAnnotation {
-      def toFirrtl: firrtl.annotations.Annotation = firrtl.passes.InlineAnnotation(toNamed)
-    }
-  )
+  if (params.inlineNoC) {
+    chisel3.experimental.annotate(this)(Seq(firrtl.passes.InlineAnnotation(toNamed)))
+  }
 
   val protocolParams       = params.protocolParams
   val minPayloadWidth      = protocolParams.map(_.minPayloadWidth).max


### PR DESCRIPTION
The `ChiselAnnotation` API is going away in Chisel 7. This API was introduced in https://github.com/chipsalliance/chisel/pull/4643 and was released in Chisel 6.7.0.

Resolves #81.