### PR TITLE
update width documentation

### DIFF
--- a/docs/source/Configuration/Routers.rst
+++ b/docs/source/Configuration/Routers.rst
@@ -100,9 +100,9 @@ a packet into more flits or merge several flits of a packet into one.
 |                                                                         |                    |
 +-------------------------------------------------------------------------+--------------------+
 
-.. Note:: When merging, the width adapter expects each packet to contain a number of flits 
+.. Note:: When merging, the width adapter requires each packet to contain a number of flits 
    that is a multiple of the merging ratio. For example, when up-scaling from 64 bits to 
-   128 bits, the width adapter requires the packet to consist of a multiple of 2 flits.
+   128 bits, the width adapter expects the packet to consist of a multiple of 2 flits.
 
 
 Virtual Channel Allocator

--- a/docs/source/Configuration/Routers.rst
+++ b/docs/source/Configuration/Routers.rst
@@ -81,7 +81,8 @@ Payload Width
 
 A router can specify its internal ``payloadWidth``. When routers with different payload
 widths are connected by a channel, Constellation will autogenerate width-adapters
-on the channels if the widths are multiples of each other. 
+on the channels if the widths are multiples of each other. A width-adapter either segments 
+a packet into more flits or merge several flits of a packet into one.
 
 
 
@@ -98,6 +99,10 @@ on the channels if the widths are multiples of each other.
 |    )                                                                    |                    |
 |                                                                         |                    |
 +-------------------------------------------------------------------------+--------------------+
+
+.. Note:: When merging, the width adapter expects each packet to contain a number of flits 
+   that is a multiple of the merging ratio. For example, when up-scaling from 64 bits to 
+   128 bits, the width adapter requires the packet to consist of a multiple of 2 flits.
 
 
 Virtual Channel Allocator

--- a/docs/source/Configuration/Terminals.rst
+++ b/docs/source/Configuration/Terminals.rst
@@ -34,14 +34,10 @@ will auto-generate width converters to either further segment or merge flits.
 +-------------------------------------------------------------------------+--------------------+
 | .. code:: scala                                                         | |terminal_width|   |
 |                                                                         |                    |
-|    ingresses = Seq(UserIngressParams(0), payloadBits=128)),             |                    |
-|    egresses  = Seq( UserEgressParams(0), payloadBits=128)),             |                    |
+|    ingresses = Seq(UserIngressParams(0, payloadBits=128)),              |                    |
+|    egresses  = Seq( UserEgressParams(1, payloadBits=128)),              |                    |
 |    routers   = (i) => UserRouterParams(payloadBits=64),                 |                    |
 |                                                                         |                    |
 +-------------------------------------------------------------------------+--------------------+
 
 .. Note:: The common use case for ``payloadWidth`` is to set the same width for all terminals.
-
-.. Warning:: Be wary of using payload width converters liberally. For example, a 3-flit packet of
-	     64 bits per flit, if up-scaled to a 2-flit packet of 128 bits per flit, will be
-	     down-scaled into a 4-flit packet of 64 bits per flit.


### PR DESCRIPTION
There is a slight mismatch between the documentation of width adapters and its actual implementation. When merging flits the WidthWidget actually awaits a number of flits that matches the ratio instead of creating "incomplete" merged flits. 
I fixed a few other typos and moved the information about merging to a place fitting better
If needed I can provide my xample configuration. 